### PR TITLE
fix: ユーザー詳細、いいねした投稿のマップ表示のバグ修正

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -13,7 +13,7 @@ class LikesController < ApplicationController
     @user = User.find(params[:user_id])
     @blogs = @user.like_blogs.order(created_at: "DESC")
     @markers_json = []
-    Blog.all.each do |blog|
+    @blogs.each do |blog|
       if blog.image?
         blog_image = blog.image.thumb.url
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @blogs = @user.blogs.order(created_at: "DESC")
     @markers_json = []
-    Blog.all.each do |blog|
+    @blogs.each do |blog|
       if blog.image?
         blog_image = blog.image.thumb.url
       else


### PR DESCRIPTION
#51 
ユーザー詳細、いいねした投稿のマップ上のマーカーが全ユーザーの投稿になっていたので、
それぞれユーザーの投稿、いいねした投稿が表示されるように修正した